### PR TITLE
Update dropzone rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Go to [this secret place](https://github.com/ncuesta/dropzonejs-rails/issues).
 
 ### Getting the latest version of Dropzone
 
-1. Run `rake check` to see if there is a newer version of Dropzone available.
-2. If **1.** tells you to do so, run `rake get` - it'll download the files four you.
+1. Run `rake dropzone:check` to see if there is a newer version of Dropzone available.
+2. If **1.** tells you that a new version is available, you can run `rake dropzone:replace` - it'll download the files for you.
+3. If **1.** tells you that a new version is available, you can run `rake dropzone:bump` - it'll download the files, commit and release them for you.
 
 ## Changelog
 

--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,9 @@ def sed(filename, replacements)
 end
 
 def new_version
-  DropzonejsRails::VERSION.next
+  parts = DropzonejsRails::VERSION.split('.')
+  parts[2] = parts[2].next
+  parts.join '.'
 end
 
 def latest_version

--- a/Rakefile
+++ b/Rakefile
@@ -11,21 +11,26 @@ require 'open-uri'
 require 'octokit'
 require 'dropzonejs-rails'
 
-desc 'Get latest dropzone js build'
-task :get do
-  puts "Fetching dropzone v#{DropzonejsRails::DROPZONE_VERSION}..."
-  download_dropzone_file 'dropzone.js', 'app/assets/javascripts/dropzone.js'
-  download_dropzone_file 'basic.css', 'app/assets/stylesheets/dropzone/basic.scss'
-  download_dropzone_file 'dropzone.css', 'app/assets/stylesheets/dropzone/dropzone.scss'
-  puts "Done"
-end
+namespace :dropzone do
+  desc 'Check if there is a more recent version of dropzone js'
+  task :check do
+    if latest_version != DropzonejsRails::DROPZONE_VERSION
+      puts "A new version of dropzone (v#{latest_version}) has been found.\nYou may now run: `rake dropzone:replace` to update it or directly rake dropzone:bump. to replace, commit and release it."
+    else
+      abort "The bundled version of dropzone (v#{DropzonejsRails::DROPZONE_VERSION}) already is the latest one."
+    end
+  end
 
-desc 'Find the latest dropzone js version and get it'
-task :check do
-  latest_version = Octokit.tags('enyo/dropzone').first.name.gsub(/[^\d\.]/, '')
-
-  if latest_version != DropzonejsRails::DROPZONE_VERSION
+  desc 'Replace latest dropzone js build by most recent'
+  task :replace do
+    puts "=> Fetching dropzone v#{DropzonejsRails::DROPZONE_VERSION}..."
+    download_dropzone_file 'dropzone.js', 'app/assets/javascripts/dropzone.js'
+    download_dropzone_file 'basic.css', 'app/assets/stylesheets/dropzone/basic.scss'
+    download_dropzone_file 'dropzone.css', 'app/assets/stylesheets/dropzone/dropzone.scss'
+    puts " ✔ Fetched"
     version = File.join(File.dirname(__FILE__), 'lib', 'dropzonejs-rails', 'version.rb')
+
+    puts "=> Update dropzonejs-rails version from '#{DropzonejsRails::VERSION}' to '#{new_version}'"
     sed version, {
       /DROPZONE_VERSION\s+=\s+'#{DropzonejsRails::DROPZONE_VERSION}'/ => "DROPZONE_VERSION = '#{latest_version}'",
       /\sVERSION\s+=\s+'#{DropzonejsRails::VERSION}'/ => " VERSION = '#{new_version}'"
@@ -33,17 +38,16 @@ task :check do
 
     readme = File.join(File.dirname(__FILE__), 'README.md')
     sed readme, { /\*\*Dropzone v#{DropzonejsRails::DROPZONE_VERSION}\*\*/ => "**Dropzone v#{latest_version}**" }
-
-    puts "A new version of dropzone (v#{latest_version}) has been found, and the source files have been accordingly updated.\nYou may now run: `rake get` to get it."
-  else
-    raise "The bundled version of dropzone (v#{DropzonejsRails::DROPZONE_VERSION}) already is the latest one."
+    puts " ✔ Done"
   end
-end
 
-desc 'Bump the dropzone js version to the latest, commit changes and perform a release'
-task bump: [:check, :get] do
-  %x{ git add -A . && git commit -m 'rake bump: Version bump' }
-  Rake::Task['release'].invoke
+  desc 'Bump the dropzone js version to the latest, commit changes and perform a release'
+  task bump: [:check, :replace] do
+    puts "=> Commit and release"
+    %x{ git add -A . && git commit -m 'rake bump: Version bump' }
+    Rake::Task['release'].invoke
+    puts " ✔ Done"
+  end
 end
 
 def download_dropzone_file(source_file, target_file)
@@ -62,7 +66,9 @@ def sed(filename, replacements)
 end
 
 def new_version
-  parts = DropzonejsRails::VERSION.split('.')
-  parts[2] = parts[2].to_i + 1
-  parts.join '.'
+  DropzonejsRails::VERSION.next
+end
+
+def latest_version
+  Octokit.tags('enyo/dropzone').first.name.gsub(/[^\d\.]/, '')
 end


### PR DESCRIPTION
Hi there,

I was checking if there is a new version of dropzone.js available and was thrown off by the fact that the check rake task was raising an error because there is no new version. So I changed it to abort. While doing that I noticed that `check` was also updating the version, which felt slightly out of place because if one doesn't want to replace with the new version, it still bumps the version, so I moved that to... a thing led to another, I refactored to the below, which basically:

- Groups the tasks in a `dropzone` namespace
- Change the `check` task so it just check and doesn't do anything else
- Change the `check` task to abort and not error out
- Add the version bump to the `get` task
- Rename the `get` task to replace, because, well, it replaces more than it gets :)
- Added a couple of `puts` statements to track what the rake task is up to better.

I hope that's ok to suggest these changes, feedback welcome.
