### PR TITLE
Replace Rails dependency with railties

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,36 +2,11 @@ PATH
   remote: .
   specs:
     dropzonejs-rails (0.8.5)
-      rails (> 3.1)
+      railties (> 3.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    actioncable (7.0.2)
-      actionpack (= 7.0.2)
-      activesupport (= 7.0.2)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.2)
-      actionpack (= 7.0.2)
-      activejob (= 7.0.2)
-      activerecord (= 7.0.2)
-      activestorage (= 7.0.2)
-      activesupport (= 7.0.2)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.2)
-      actionpack (= 7.0.2)
-      actionview (= 7.0.2)
-      activejob (= 7.0.2)
-      activesupport (= 7.0.2)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
     actionpack (7.0.2)
       actionview (= 7.0.2)
       activesupport (= 7.0.2)
@@ -39,34 +14,12 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.2)
-      actionpack (= 7.0.2)
-      activerecord (= 7.0.2)
-      activestorage (= 7.0.2)
-      activesupport (= 7.0.2)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
     actionview (7.0.2)
       activesupport (= 7.0.2)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.2)
-      activesupport (= 7.0.2)
-      globalid (>= 0.3.6)
-    activemodel (7.0.2)
-      activesupport (= 7.0.2)
-    activerecord (7.0.2)
-      activemodel (= 7.0.2)
-      activesupport (= 7.0.2)
-    activestorage (7.0.2)
-      actionpack (= 7.0.2)
-      activejob (= 7.0.2)
-      activerecord (= 7.0.2)
-      activesupport (= 7.0.2)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
     activesupport (7.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -77,7 +30,6 @@ GEM
     builder (3.2.4)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
-    digest (3.1.0)
     erubi (1.10.0)
     faraday (1.9.3)
       faraday-em_http (~> 1.0)
@@ -102,38 +54,15 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    globalid (1.0.0)
-      activesupport (>= 5.0)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
-    io-wait (0.2.1)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
-      mini_mime (>= 0.1.1)
-    marcel (1.0.2)
     method_source (1.0.0)
-    mini_mime (1.1.2)
     mini_portile2 (2.7.1)
     minitest (5.15.0)
     multipart-post (2.1.1)
-    net-imap (0.2.3)
-      digest
-      net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
-      net-protocol
-      timeout
-    net-protocol (0.1.2)
-      io-wait
-      timeout
-    net-smtp (0.3.1)
-      digest
-      net-protocol
-      timeout
-    nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
@@ -145,20 +74,6 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (7.0.2)
-      actioncable (= 7.0.2)
-      actionmailbox (= 7.0.2)
-      actionmailer (= 7.0.2)
-      actionpack (= 7.0.2)
-      actiontext (= 7.0.2)
-      actionview (= 7.0.2)
-      activejob (= 7.0.2)
-      activemodel (= 7.0.2)
-      activerecord (= 7.0.2)
-      activestorage (= 7.0.2)
-      activesupport (= 7.0.2)
-      bundler (>= 1.15.0)
-      railties (= 7.0.2)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -176,14 +91,9 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    strscan (3.0.1)
     thor (1.2.1)
-    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     zeitwerk (2.5.4)
 
 PLATFORMS

--- a/dropzonejs-rails.gemspec
+++ b/dropzonejs-rails.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'octokit', '~> 4.0'
   s.add_development_dependency 'faraday', '>= 0.9'
 
-  s.add_dependency 'rails', '> 3.1'
+  s.add_dependency 'railties', '> 3.1'
 end


### PR DESCRIPTION
Allows usage with minimal Rails installs that do not include all Rails gems.

This gem directly uses `Rails::Generators::Base` and `Rails::Engine`. Both of these are available in the `railties` gem.